### PR TITLE
fix bug with conditional middleware

### DIFF
--- a/src/builder.lisp
+++ b/src/builder.lisp
@@ -64,9 +64,10 @@
                    (typecase ,res
                      (keyword (find-middleware ,res))
                      (cons (if (keywordp (car ,res))
-                               `(lambda (,',app)
-                                  (apply (find-middleware (car ,,res)) ,',app
-                                         (cdr ,,res)))
+                               (eval
+                                `(lambda (,',app)
+                                   (apply (find-middleware (car ',,res)) ,',app
+                                          (cdr ',,res))))
                                ,res))
                      (otherwise ,res))))))
          (otherwise mw)))

--- a/t/builder.lisp
+++ b/t/builder.lisp
@@ -5,7 +5,7 @@
         :lack.builder))
 (in-package :t.lack.builder)
 
-(plan 8)
+(plan 10)
 
 (defvar *app*
   (lambda (env)
@@ -46,5 +46,34 @@
       '("admin" "/"))
   (is (nth 2 (funcall mount-app '(:path-info "/administrators")))
       '("ok from app")))
+
+(defpackage lack.middleware.sample
+  (:use :cl))
+
+(defvar lack.middleware.sample::*lack-middleware-sample*
+  (lambda (app &key (out (lambda (out) (princ out))))
+    (lambda (env)
+      (funcall out "sample")
+      (funcall app env))))
+
+(subtest "Embedded CL code with Middleware without keyword option."
+  (let ((app (builder (when t :sample) *app*)))
+    (is-type app
+           'function
+           "Can build.")
+
+    (is-print (funcall app '(:path-info "/"))
+              "sample"
+              "Can work.")))
+
+(subtest "Embedded CL code with Middleware with keyword option."
+  (let ((app (builder (when t `(:sample :out ,(lambda (out) (format t "Got: ~a" out)))) *app*)))
+    (is-type app
+           'function
+           "Can build.")
+
+    (is-print (funcall app '(:path-info "/"))
+              "Got: sample"
+              "Can work.")))
 
 (finalize)


### PR DESCRIPTION
``` Lisp
(builder (when t `(:sample :out (lambda (out) (princ out)))) *app*)
```

doesn't work well, because `convert-to-middleware-form` with CL-form returning `cons` returned the form evaluated to `'(lambda (app) )` but not `(lambda (app) )`.
