### PR TITLE
accesslog with response which body is vector.

### DIFF
--- a/src/util.lisp
+++ b/src/util.lisp
@@ -43,7 +43,9 @@
         (etypecase body
           (list (reduce #'+ body :key #'length))
           (pathname (with-open-file (in body)
-                      (file-length in)))))))
+                      (file-length in)))
+          ((vector (unsigned-byte 8))
+           (length body))))))
 
 (defun generate-random-id ()
   "Generates a random token."

--- a/t/middleware/accesslog.lisp
+++ b/t/middleware/accesslog.lisp
@@ -7,7 +7,7 @@
         :split-sequence))
 (in-package :t.lack.middleware.accesslog)
 
-(plan 6)
+(plan 8)
 
 (defmacro with-accesslogs ((var &rest forms) &body body)
   `(let* ((,var (string-right-trim '(#\Newline)
@@ -16,17 +16,30 @@
           (,var (split-sequence #\Newline ,var)))
      ,@body))
 
-(let ((app (builder :accesslog
+(let ((app1 (builder :accesslog
                     (lambda (env)
                       (declare (ignore env))
-                      '(200 () ("ok"))))))
-  (with-accesslogs (logs (funcall app (generate-env "/")))
+                      '(200 () ("ok")))))
+      (app2 (builder :accesslog
+                    (lambda (env)
+                      (declare (ignore env))
+                      `(200 () ,(babel:string-to-octets "ok"))))))
+
+  (with-accesslogs (logs (funcall app1 (generate-env "/")))
+    (ok logs
+        "Body of response is list of strings."))
+
+  (with-accesslogs (logs (funcall app2 (generate-env "/")))
+    (ok logs
+        "Body of response is (vector (unsigned-byte 8))."))
+
+  (with-accesslogs (logs (funcall app1 (generate-env "/")))
     (is (length logs) 1 "1 line") 
     (like (car logs) "^127.0.0.1 - \\[.+?\\] \"GET / "))
 
-  (with-accesslogs (logs (funcall app (generate-env "/"))
-                         (funcall app (generate-env "/users"))
-                         (funcall app (generate-env "/new" :method :post)))
+  (with-accesslogs (logs (funcall app1 (generate-env "/"))
+                         (funcall app1 (generate-env "/users"))
+                         (funcall app1 (generate-env "/new" :method :post)))
     (is (length logs) 3 "3 lines")
     (like (nth 0 logs) "^127.0.0.1 - \\[.+?\\] \"GET / ")
     (like (nth 1 logs) "^127.0.0.1 - \\[.+?\\] \"GET /users ")


### PR DESCRIPTION
Middleware using `lack.util:content-length` can not handle response having vector as its body part.(i.e. `accesslog`)
