### PR TITLE
Fix a simple-file-error in lack.middleware.static for special path-info

### DIFF
--- a/src/app/file.lisp
+++ b/src/app/file.lisp
@@ -43,7 +43,11 @@
     (cond
       ((position #\Null (namestring file))
        (error 'bad-request))
-      ((not (and (file-exists-p file)
+      ((not (and (ignore-errors
+                  ;; Ignore simple-file-error in a case that
+                  ;; the file path contains some special characters like "?".
+                  ;; See https://github.com/fukamachi/clack/issues/111
+                  (file-exists-p file))
                  (not (directory-exists-p file))))
        (error 'not-found))
       (t file))))

--- a/t/middleware/static.lisp
+++ b/t/middleware/static.lisp
@@ -8,7 +8,7 @@
                 :starts-with-subseq))
 (in-package :t.lack.middleware.static)
 
-(plan 3)
+(plan 4)
 
 (subtest ":path is string"
   (let ((app
@@ -67,5 +67,18 @@
       (is body (asdf:system-relative-pathname :lack #P"data/jellyfish.jpg")))
 
     (is (car (funcall app (generate-env "/static/not-found.png"))) 404)))
+
+(subtest "special character in path-info"
+  (let ((app
+          (builder
+           (:static :path (lambda (path-info)
+                            (when (starts-with-subseq "/static/" path-info)
+                              (subseq path-info #.(length "/static"))))
+                    :root (asdf:system-relative-pathname :lack #P"data/"))
+           (lambda (env)
+             (declare (ignore env))
+             `(200 (:content-type "text/plain") ("ok"))))))
+    (is (first (funcall app (generate-env "/static/?broken=yup"))) 404)
+    (is (first (funcall app (generate-env "/static/%3Fbroken=yup"))) 404)))
 
 (finalize)


### PR DESCRIPTION
In a case that `:path-info` in ENV contains some special characters like '?', `probe-file` raises a simple-file-error with SBCL.

This will fix fukamachi/clack#111.
