### PR TITLE
Cleanup session middleware

### DIFF
--- a/lack-middleware-session.asd
+++ b/lack-middleware-session.asd
@@ -9,7 +9,9 @@
   :license "LLGPL"
   :depends-on (:lack-request
                :lack-response
-               :lack-util)
+               :lack-util
+               :marshal
+               :cl-base64)
   :components ((:module "src/middleware"
                 :components
                 ((:file "session" :depends-on ("store" "state"))
@@ -17,7 +19,8 @@
                   :pathname "session"
                   :components
                   ((:file "store")
-                   (:file "store/memory")))
+                   (:file "store/memory")
+                   (:file "store/client")))
                  (:module "state"
                   :pathname "session"
                   :components

--- a/lack-middleware-session.asd
+++ b/lack-middleware-session.asd
@@ -9,8 +9,7 @@
   :license "LLGPL"
   :depends-on (:lack-request
                :lack-response
-               :lack-util
-               :cl-ppcre)
+               :lack-util)
   :components ((:module "src/middleware"
                 :components
                 ((:file "session" :depends-on ("store" "state"))

--- a/lack-util.asd
+++ b/lack-util.asd
@@ -8,6 +8,7 @@
   :author "Eitaro Fukamachi"
   :license "LLGPL"
   :depends-on (:ironclad
-               :alexandria)
+               :alexandria
+               :cl-ppcre)
   :components ((:file "src/util"))
   :in-order-to ((test-op (test-op t-lack-util))))

--- a/src/middleware/session.lisp
+++ b/src/middleware/session.lisp
@@ -2,14 +2,15 @@
 (defpackage lack.middleware.session
   (:use :cl)
   (:import-from :lack.session.store
+                :session-id
+                :session-data
                 :fetch-session
                 :store-session
                 :remove-session)
   (:import-from :lack.session.state
                 :expire-state
                 :extract-sid
-                :finalize-state
-                :generate-sid)
+                :finalize-state)
   (:import-from :lack.session.store.memory
                 :make-memory-store)
   (:import-from :lack.session.state.cookie
@@ -23,33 +24,28 @@
             (state (make-cookie-state)))
     (lambda (env)
       (let* ((sid (extract-sid state env))
-             (session (and sid
-                           (fetch-session store sid)))
-             (sid (or sid
-                      (generate-sid state env))))
+             (session (fetch-session store sid)))
         (setf (getf env :lack.session)
-              (or session (make-hash-table :test 'equal)))
+              (session-data session))
         (setf (getf env :lack.session.options)
               (list :id sid))
-        (finalize store state env (funcall app env)))))
+        (finalize store state env session sid (funcall app env)))))
   "Middleware for session management")
 
-(defun finalize (store state env res)
-  (let ((session (getf env :lack.session))
-        (options (getf env :lack.session.options)))
+(defun finalize (store state env session request-sid res)
+  (let ((options (getf env :lack.session.options)))
     (when session
-      (apply #'commit store state session env options))
+      (apply #'commit store session options))
     (if (getf options :expire)
-        (expire-state state (getf options :id) res options)
-        (finalize-state state (getf options :id) res options))))
+        (expire-state state request-sid res options)
+        (finalize-state state (session-id session) res options))))
 
-(defun commit (store state session env &key id expire change-id &allow-other-keys)
+(defun commit (store session &key expire change-id &allow-other-keys)
   (cond
     (expire
-     (remove-session store id))
+     (remove-session store session))
     (change-id
-     (remove-session store id)
-     (let ((new-sid (generate-sid state env)))
-       (store-session store new-sid session)))
+     (remove-session store session)
+     (store-session store session))
     (t
-     (store-session store id session))))
+     (store-session store session))))

--- a/src/middleware/session/state.lisp
+++ b/src/middleware/session/state.lisp
@@ -2,14 +2,10 @@
 (defpackage lack.middleware.session.state
   (:nicknames :lack.session.state)
   (:use :cl)
-  (:export :state
-           :make-state
-           :extract-sid
+  (:export :extract-sid
            :expire-state
            :finalize-state))
 (in-package :lack.middleware.session.state)
-
-(defstruct state)
 
 (defgeneric extract-sid (state env))
 (defgeneric expire-state (state sid res options))

--- a/src/middleware/session/state.lisp
+++ b/src/middleware/session/state.lisp
@@ -3,9 +3,8 @@
   (:nicknames :lack.session.state)
   (:use :cl)
   (:import-from :lack.util
-                :generate-random-id)
-  (:import-from :cl-ppcre
-                :scan)
+                :generate-random-id
+                :valid-id-p)
   (:export :state
            :make-state
            :generate-sid
@@ -18,8 +17,7 @@
   (sid-generator (lambda (env)
                    (declare (ignore env))
                    (generate-random-id)))
-  (sid-validator (lambda (sid)
-                   (not (null (ppcre:scan "\\A[0-9a-f]{40}\\Z" sid))))))
+  (sid-validator #'valid-id-p))
 
 (defun generate-sid (state env)
   (funcall (state-sid-generator state) env))

--- a/src/middleware/session/state.lisp
+++ b/src/middleware/session/state.lisp
@@ -2,33 +2,15 @@
 (defpackage lack.middleware.session.state
   (:nicknames :lack.session.state)
   (:use :cl)
-  (:import-from :lack.util
-                :generate-random-id
-                :valid-id-p)
   (:export :state
            :make-state
-           :generate-sid
            :extract-sid
            :expire-state
            :finalize-state))
 (in-package :lack.middleware.session.state)
 
-(defstruct state
-  (sid-generator (lambda (env)
-                   (declare (ignore env))
-                   (generate-random-id)))
-  (sid-validator #'valid-id-p))
-
-(defun generate-sid (state env)
-  (funcall (state-sid-generator state) env))
+(defstruct state)
 
 (defgeneric extract-sid (state env))
-(defmethod extract-sid :around ((state state) env)
-  (let ((sid (call-next-method)))
-    (when (and sid
-               (funcall (state-sid-validator state) sid))
-      sid)))
-
 (defgeneric expire-state (state sid res options))
-
 (defgeneric finalize-state (state sid res options))

--- a/src/middleware/session/state/cookie.lisp
+++ b/src/middleware/session/state/cookie.lisp
@@ -14,7 +14,6 @@
                 :remove-from-plist)
   (:export :cookie-state
            :make-cookie-state
-           :generate-sid
            :extract-sid
            :expire-state
            :finalize-session))

--- a/src/middleware/session/state/cookie.lisp
+++ b/src/middleware/session/state/cookie.lisp
@@ -19,7 +19,7 @@
            :finalize-session))
 (in-package :lack.middleware.session.state.cookie)
 
-(defstruct (cookie-state (:include state))
+(defstruct cookie-state
   (path "/" :type string)
   (domain nil :type (or string null))
   (expires (get-universal-time) :type integer)

--- a/src/middleware/session/store.lisp
+++ b/src/middleware/session/store.lisp
@@ -3,13 +3,30 @@
   (:nicknames :lack.session.store)
   (:use :cl)
   (:export :store
+           :session-id
+           :session-data
+           :make-session
            :fetch-session
            :store-session
            :remove-session))
 (in-package :lack.middleware.session.store)
 
+(defstruct session
+  id
+  (data (make-hash-table :test 'equal)))
+
 (defstruct store)
 
 (defgeneric fetch-session (store sid))
-(defgeneric store-session (store sid session))
-(defgeneric remove-session (store sid))
+(defgeneric store-session (store session))
+(defgeneric remove-session (store session))
+
+(defmethod fetch-session :around ((store t) sid)
+  (or (call-next-method)
+      (make-session)))
+
+(defmethod fetch-session (store (sid (eql nil)))
+  (make-session))
+
+(defmethod remove-session :after ((store t) session)
+  (setf (session-id session) nil))

--- a/src/middleware/session/store.lisp
+++ b/src/middleware/session/store.lisp
@@ -2,8 +2,7 @@
 (defpackage lack.middleware.session.store
   (:nicknames :lack.session.store)
   (:use :cl)
-  (:export :store
-           :session-id
+  (:export :session-id
            :session-data
            :make-session
            :fetch-session
@@ -14,8 +13,6 @@
 (defstruct session
   id
   (data (make-hash-table :test 'equal)))
-
-(defstruct store)
 
 (defgeneric fetch-session (store sid))
 (defgeneric store-session (store session))

--- a/src/middleware/session/store/client.lisp
+++ b/src/middleware/session/store/client.lisp
@@ -1,0 +1,40 @@
+(in-package :cl-user)
+(defpackage lack.middleware.session.store.client
+  (:nicknames :lack.session.store.client)
+  (:use :cl
+        :lack.middleware.session.store)
+  (:import-from :marshal
+                :marshal
+                :unmarshal)
+  (:import-from :cl-base64
+                :base64-string-to-string
+                :string-to-base64-string)
+  (:import-from :lack.util
+                :hmac-signature
+                :generate-random-id)
+  (:export :make-client-store))
+(in-package :lack.middleware.session.store.client)
+
+(defstruct client-store
+  (secret-key (generate-random-id))
+  (serializer (lambda (data)
+                (string-to-base64-string (prin1-to-string (marshal data)))))
+  (deserializer (lambda (data)
+                  (unmarshal (read-from-string (base64-string-to-string data))))))
+
+(defmethod fetch-session ((store client-store) sid)
+  (let ((separator (position #\| sid)))
+    (when separator
+      (let ((data (subseq sid 0 separator))
+            (sign (subseq sid (1+ separator)))
+            (secret (client-store-secret-key store)))
+        (when (string= (hmac-signature secret data) sign)
+          (make-session :data (funcall (client-store-deserializer store) data)))))))
+
+(defmethod store-session ((store client-store) session)
+  (setf (session-id session)
+        (let ((data (funcall (client-store-serializer store) (session-data session)))
+              (secret (client-store-secret-key store)))
+          (concatenate 'string data "|" (hmac-signature secret data)))))
+
+(defmethod remove-session ((store client-store) session)) ;; no-op

--- a/src/middleware/session/store/dbi.lisp
+++ b/src/middleware/session/store/dbi.lisp
@@ -12,14 +12,10 @@
   (:import-from :cl-base64
                 :base64-string-to-string
                 :string-to-base64-string)
-  (:export :dbi-store
-           :make-dbi-store
-           :fetch-session
-           :store-session
-           :remove-session))
+  (:export :make-dbi-store))
 (in-package :lack.middleware.session.store.dbi)
 
-(defstruct (dbi-store (:include store))
+(defstruct dbi-store
   (connector nil :type function)
   (serializer (lambda (data)
                 (string-to-base64-string (prin1-to-string (marshal data)))))

--- a/src/middleware/session/store/memory.lisp
+++ b/src/middleware/session/store/memory.lisp
@@ -6,14 +6,10 @@
   (:import-from :lack.util
                 :generate-random-id
                 :valid-id-p)
-  (:export :memory-store
-           :make-memory-store
-           :fetch-session
-           :store-session
-           :remove-session))
+  (:export :make-memory-store))
 (in-package :lack.middleware.session.store.memory)
 
-(defstruct (memory-store (:include store))
+(defstruct memory-store
   (stash (make-hash-table :test 'equal)))
 
 (defmethod fetch-session ((store memory-store) sid)

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -7,7 +7,10 @@
                 :ascii-string-to-byte-array
                 :byte-array-to-hex-string
                 :digest-sequence
-                :make-digest)
+                :make-digest
+                :make-hmac
+                :update-hmac
+                :hmac-digest)
   (:import-from :alexandria
                 :when-let)
   (:export :find-package-or-load
@@ -15,7 +18,8 @@
            :funcall-with-cb
            :content-length
            :generate-random-id
-           :valid-id-p))
+           :valid-id-p
+           :hmac-signature))
 (in-package :lack.util)
 
 (defun find-package-or-load (package-name)
@@ -78,3 +82,8 @@
 
 (defun valid-id-p (id)
   (not (null (ppcre:scan "\\A[0-9a-f]{40}\\Z" id))))
+
+(defun hmac-signature (key message &optional (digest-name :sha256))
+  (let ((hmac (make-hmac (ascii-string-to-byte-array key) digest-name)))
+    (update-hmac hmac (ascii-string-to-byte-array message))
+    (byte-array-to-hex-string (hmac-digest hmac))))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -1,6 +1,8 @@
 (in-package :cl-user)
 (defpackage lack.util
   (:use :cl)
+  (:import-from :cl-ppcre
+                :scan)
   (:import-from :ironclad
                 :ascii-string-to-byte-array
                 :byte-array-to-hex-string
@@ -12,7 +14,8 @@
            :find-middleware
            :funcall-with-cb
            :content-length
-           :generate-random-id))
+           :generate-random-id
+           :valid-id-p))
 (in-package :lack.util)
 
 (defun find-package-or-load (package-name)
@@ -72,3 +75,6 @@
     (ascii-string-to-byte-array
      (format nil "~A~A"
       (random 1.0) (get-universal-time))))))
+
+(defun valid-id-p (id)
+  (not (null (ppcre:scan "\\A[0-9a-f]{40}\\Z" id))))

--- a/t/middleware/session.lisp
+++ b/t/middleware/session.lisp
@@ -8,10 +8,7 @@
                 :make-client-store))
 (in-package :t.lack.middleware.session)
 
-(plan 4)
-
-(ok (lack.session.state:make-state)
-    "Base class of session state")
+(plan 3)
 
 (defgeneric with-response% (response handler)
   (:method ((response list) handler)

--- a/t/util.lisp
+++ b/t/util.lisp
@@ -6,7 +6,7 @@
         :lack.test))
 (in-package :t.lack.util)
 
-(plan 3)
+(plan 4)
 
 (subtest "find-package-or-load"
   (is (find-package-or-load "LACK")
@@ -44,5 +44,11 @@
       t)
   (is (valid-id-p "invalid id")
       nil))
+
+(subtest "hmac-signature"
+  (is (hmac-signature "secret" "Hello, World!")
+      "fcfaffa7fef86515c7beb6b62d779fa4ccf092f2e61c164376054271252821ff")
+  (is (hmac-signature "secret" "Hello, World!" :sha1)
+      "883a982dc2ae46d20f7f106c786a9241b60dc340"))
 
 (finalize)

--- a/t/util.lisp
+++ b/t/util.lisp
@@ -6,7 +6,7 @@
         :lack.test))
 (in-package :t.lack.util)
 
-(plan 2)
+(plan 3)
 
 (subtest "find-package-or-load"
   (is (find-package-or-load "LACK")
@@ -38,5 +38,11 @@
                  (declare (ignore env))
                  1)))
       (is (funcall-with-cb app (generate-env "/") cb) 1))))
+
+(subtest "generate-random-id / valid-id-p"
+  (is (valid-id-p (generate-random-id))
+      t)
+  (is (valid-id-p "invalid id")
+      nil))
 
 (finalize)


### PR DESCRIPTION
This pull-request removes unused structures and exports. So store and state implementations become opaque objects with only interfaces declared by corresponding generic functions.
