### PR TITLE
handle multipart/form-data's text/*.

### DIFF
--- a/lack-request.asd
+++ b/lack-request.asd
@@ -8,6 +8,8 @@
   :author "Eitaro Fukamachi"
   :license "LLGPL"
   :depends-on (:quri
+               :babel
+               :split-sequence
                :http-body
                :cl-ppcre)
   :components ((:file "src/request")))

--- a/src/request.lisp
+++ b/src/request.lisp
@@ -1,10 +1,16 @@
 (in-package :cl-user)
 (defpackage lack.request
   (:use :cl)
+  (:import-from :alexandria
+                :when-let*)
   (:import-from :quri
                 :url-decode-params)
   (:import-from :http-body
                 :parse)
+  (:import-from :http-body.util
+                :slurp-stream)
+  (:import-from :split-sequence
+                :split-sequence)
   (:import-from :cl-ppcre
                 :split)
   (:export :request
@@ -52,6 +58,44 @@
   body-parameters
   query-parameters)
 
+(defun handle-multipart-body (body)
+  (let ((encoding (babel-encodings:get-character-encoding :utf-8)))
+    (labels ((strip (str)
+               (string-trim '(#\Space #\Tab #\Newline) str))
+             (handle-body (encoding name body)
+               (if (gethash "filename" (cadr body) nil)
+                   (cons name body)
+                   (progn
+                     (when-let* ((contentType
+                                  (gethash "content-type" (caddr body) nil))
+                                 (content-type-list
+                                  (split-sequence #\; contentType))
+                                 (type-subtype
+                                  (car content-type-list)))
+                       (when (string= type-subtype "text/" :end1 5)
+                         (loop
+                            for param in (split-sequence #\=
+                                                         (cdr content-type-list))
+                            for key = (strip (car param))
+                            for val = (strip (cadr param))
+                            do
+                              (when (string= key "charset")
+                                (setf encoding
+                                      (babel-encodings:get-character-encoding
+                                       val))
+                                (return nil)))))
+                     (cons name
+                           (cons (babel:octets-to-string
+                                  (slurp-stream (car body)) :encoding encoding)
+                                 (cdr body)))))))
+      (loop
+         for pair in body
+         for key = (car pair)
+         for val = (cdr pair)
+         collect
+           (handle-body encoding key val)))))
+
+
 (defun make-request (env)
   (let ((req (apply #'%make-request :env env :allow-other-keys t env)))
     (with-slots (method uri) req
@@ -83,12 +127,14 @@
     (with-slots (body-parameters raw-body content-length content-type) req
       (when (and (null body-parameters)
                  raw-body)
-        (setf body-parameters
-              (http-body:parse content-type content-length raw-body))
+        (let ((parsed-body
+               (http-body:parse content-type content-length raw-body)))
+          (if (string-equal content-type "multipart/form-data" :end1
+                            (length "multipart/form-data"))
+              (setf body-parameters (handle-multipart-body parsed-body))
+              (setf body-parameters parsed-body)))
         (rplacd (last env) (list :body-parameters body-parameters))))
-
     (setf (request-env req) env)
-
     req))
 
 (defun request-parameters (req)

--- a/src/request.lisp
+++ b/src/request.lisp
@@ -2,7 +2,8 @@
 (defpackage lack.request
   (:use :cl)
   (:import-from :alexandria
-                :when-let*)
+                :when-let*
+                :make-keyword)
   (:import-from :quri
                 :url-decode-params)
   (:import-from :http-body
@@ -82,7 +83,8 @@
                               (when (string= key "charset")
                                 (when-let (charset-encoding
                                            (handler-case
-                                               (babel-encodings:get-character-encoding val)
+                                               (babel-encodings:get-character-encoding
+                                                (make-keyword (string-upcase val)))
                                              (simple-error (c)
                                                (warn "Unknown charset: ~A~% specified for ~A value."
                                                      val name))))


### PR DESCRIPTION
I think it is better to treat 'text/*' in multipart/form-data into text not pure vector-stream.
