### PR TITLE
Send Set-Cookie header only when it's necessary

### DIFF
--- a/src/middleware/session.lisp
+++ b/src/middleware/session.lisp
@@ -30,7 +30,9 @@
         (setf (getf env :lack.session)
               (or session (make-hash-table :test 'equal)))
         (setf (getf env :lack.session.options)
-              (list :id sid))
+              (if session
+                  (list :id sid)
+                  (list :id sid :new-session t)))
         (finalize store state env (funcall app env)))))
   "Middleware for session management")
 


### PR DESCRIPTION
This can reduce network traffic when using Lack.Middleware.Session.
