### PR TITLE
Don't permanently expire all future sessions.

### DIFF
--- a/src/middleware/session/state/cookie.lisp
+++ b/src/middleware/session/state/cookie.lisp
@@ -30,8 +30,11 @@
     (cdr (assoc "lack.session" (request-cookies req) :test #'string=))))
 
 (defmethod expire-state ((state cookie-state) sid res options)
-  (setf (cookie-state-expires state) 0)
-  (finalize-state state sid res options))
+  (let ((expiration (cookie-state-expires state)))
+    (setf (cookie-state-expires state) 0)
+    (unwind-protect
+        (finalize-state state sid res options)
+      (setf (cookie-state-expires state) expiration))))
 
 (defmethod finalize-state ((state cookie-state) sid (res function) options)
   (lambda (responder)


### PR DESCRIPTION
By modifying the global cookie session state's expiration time to 0,
every subsequent request will get a session cookie that immediately
expires, which effectively means that sessions will be unavailable after
the first one is expired.
