### PR TITLE
Allow to change the cookie key of Lack Session

### DIFF
--- a/src/middleware/session/state/cookie.lisp
+++ b/src/middleware/session/state/cookie.lisp
@@ -23,11 +23,13 @@
   (domain nil :type (or string null))
   (expires (get-universal-time) :type integer)
   (secure nil :type boolean)
-  (httponly nil :type boolean))
+  (httponly nil :type boolean)
+  (cookie-key "lack.session" :type string))
 
 (defmethod extract-sid ((state cookie-state) env)
   (let ((req (make-request env)))
-    (cdr (assoc "lack.session" (request-cookies req) :test #'string=))))
+    (cdr (assoc (cookie-state-cookie-key state)
+                (request-cookies req) :test #'string=))))
 
 (defmethod expire-state ((state cookie-state) sid res options)
   (setf (getf options :expires) 0)
@@ -54,6 +56,6 @@
                          :httponly httponly
                          :expires (+ (get-universal-time)
                                      (getf options :expires expires))))))
-    (setf (getf (response-set-cookies res) :|lack.session|)
+    (setf (getf (response-set-cookies res) (cookie-state-cookie-key state))
           `(:value ,sid ,@options))
     (finalize-response res)))

--- a/src/response.lisp
+++ b/src/response.lisp
@@ -44,7 +44,7 @@
       value
     (with-output-to-string (s)
       (format s "~A=~A"
-              (quri:url-encode (symbol-name key))
+              (quri:url-encode (string key))
               (quri:url-encode (getf value :value)))
       (when domain
         (format s "; domain=~A" domain))

--- a/t/middleware/session.lisp
+++ b/t/middleware/session.lisp
@@ -6,7 +6,7 @@
         :lack.test))
 (in-package :t.lack.middleware.session)
 
-(plan 5)
+(plan 6)
 
 (ok (lack.session.state:make-state)
     "Base class of session state")
@@ -141,5 +141,17 @@
         (funcall app (generate-env "/session"))
       (declare (ignore status body))
       (is-type (getf headers :set-cookie) 'string))))
+
+(subtest "cookie-key other than lack.session="
+  (let ((app (builder
+              (:session :state (lack.session.state.cookie:make-cookie-state
+                                :cookie-key "_myapp_cookie"))
+              (lambda (env)
+                (declare (ignore env))
+                '(200 () ("hi"))))))
+    (destructuring-bind (status headers body)
+        (funcall app (generate-env "/"))
+      (declare (ignore status body))
+      (like (getf headers :set-cookie) "^_myapp_cookie="))))
 
 (finalize)


### PR DESCRIPTION
The default is still "lack.session".

Example:

```
(builder
 (:session :state (lack.session.state.cookie:make-cookie-state
                   :cookie-key "_myapp_cookie"))
 (lambda (env)
   '(200 () ("hi"))))
```
