### PR TITLE
Bugfix with session.store.dbi: make it possible to close the DB connection

### DIFF
--- a/src/middleware/session/store/dbi.lisp
+++ b/src/middleware/session/store/dbi.lisp
@@ -19,8 +19,16 @@
            :remove-session))
 (in-package :lack.middleware.session.store.dbi)
 
+(defmacro with-db-connection (connection store &body body)
+  `(let ((,connection (funcall (dbi-store-connector ,store))))
+     (unwind-protect
+          (progn ,@body)
+       (when (dbi-store-disconnector ,store)
+         (funcall (dbi-store-disconnector ,store) ,connection)))))
+
 (defstruct (dbi-store (:include store))
   (connector nil :type function)
+  (disconnector nil)
   (serializer (lambda (data)
                 (usb8-array-to-base64-string
                  (string-to-utf-8-bytes (prin1-to-string (marshal data))))))
@@ -31,20 +39,20 @@
   (table-name "sessions"))
 
 (defmethod fetch-session ((store dbi-store) sid)
-  (let* ((conn (funcall (dbi-store-connector store)))
-         (query (dbi:prepare conn
-                             (format nil "SELECT session_data FROM ~A WHERE id = ?"
-                                     (dbi-store-table-name store))))
-         (result (dbi:fetch (dbi:execute query sid))))
-    (if result
-        (handler-case (funcall (dbi-store-deserializer store) (getf result :|session_data|))
-          (error (e)
-            (warn "Error (~A) occured while deserializing a session. Ignoring.~2%    Data:~%        ~A~2%    Error:~%        ~A"
-                  (class-name (class-of e))
-                  (getf result :|session_data|)
-                  e)
-            nil))
-        nil)))
+  (with-db-connection conn store
+    (let* ((query (dbi:prepare conn
+                               (format nil "SELECT session_data FROM ~A WHERE id = ?"
+                                       (dbi-store-table-name store))))
+           (result (dbi:fetch (dbi:execute query sid))))
+      (if result
+          (handler-case (funcall (dbi-store-deserializer store) (getf result :|session_data|))
+            (error (e)
+              (warn "Error (~A) occured while deserializing a session. Ignoring.~2%    Data:~%        ~A~2%    Error:~%        ~A"
+                    (class-name (class-of e))
+                    (getf result :|session_data|)
+                    e)
+              nil))
+         nil))))
 
 (defun current-timestamp ()
   (multiple-value-bind (sec min hour date month year)
@@ -54,36 +62,37 @@
             hour min sec)))
 
 (defmethod store-session ((store dbi-store) sid session)
-  (let ((conn (funcall (dbi-store-connector store)))
-        (serialized-session (funcall (dbi-store-serializer store) session)))
-    (dbi:with-transaction conn
-      (let* ((query (dbi:prepare conn
-                                 (format nil "SELECT session_data FROM ~A WHERE id = ?"
-                                         (dbi-store-table-name store))))
-             (current-session (getf (dbi:fetch (dbi:execute query sid)) :|session_data|)))
-        (cond
-          ;; Session exists but not changed
-          ((equal current-session serialized-session))
-          ;; Session exists and is going to be changed
-          (current-session
-           (dbi:do-sql conn
-             (format nil "UPDATE ~A SET session_data = ?~:[~*~;, updated_at = '~A'~] WHERE id = ?"
-                     (dbi-store-table-name store)
-                     (dbi-store-record-timestamps store)
-                     (current-timestamp))
-             serialized-session
-             sid))
-          ;; New session
-          (t
-           (dbi:do-sql conn (format nil "INSERT INTO ~A (id, session_data~:[~;, created_at, updated_at~]) VALUES (?, ?~:*~:[~*~;, '~A', ~:*'~A'~])"
-                                    (dbi-store-table-name store)
-                                    (dbi-store-record-timestamps store)
-                                    (current-timestamp))
-             sid
-             serialized-session)))))))
+  (with-db-connection conn store
+    (let ((serialized-session (funcall (dbi-store-serializer store) session)))
+      (dbi:with-transaction conn
+        (let* ((query (dbi:prepare conn
+                                   (format nil "SELECT session_data FROM ~A WHERE id = ?"
+                                           (dbi-store-table-name store))))
+               (current-session (getf (dbi:fetch (dbi:execute query sid)) :|session_data|)))
+          (cond
+            ;; Session exists but not changed
+            ((equal current-session serialized-session))
+            ;; Session exists and is going to be changed
+            (current-session
+             (dbi:do-sql conn
+               (format nil "UPDATE ~A SET session_data = ?~:[~*~;, updated_at = '~A'~] WHERE id = ?"
+                       (dbi-store-table-name store)
+                       (dbi-store-record-timestamps store)
+                       (current-timestamp))
+               serialized-session
+               sid))
+            ;; New session
+            (t
+             (dbi:do-sql conn (format nil "INSERT INTO ~A (id, session_data~:[~;, created_at, updated_at~]) VALUES (?, ?~:*~:[~*~;, '~A', ~:*'~A'~])"
+                                      (dbi-store-table-name store)
+                                      (dbi-store-record-timestamps store)
+                                      (current-timestamp))
+                         sid
+                         serialized-session))))))))
 
 (defmethod remove-session ((store dbi-store) sid)
-  (dbi:do-sql (funcall (dbi-store-connector store))
-    (format nil "DELETE FROM ~A WHERE id = ?"
-            (dbi-store-table-name store))
-    sid))
+  (with-db-connection conn store
+    (dbi:do-sql conn
+      (format nil "DELETE FROM ~A WHERE id = ?"
+              (dbi-store-table-name store))
+      sid)))


### PR DESCRIPTION
`dbi-store` structs now have a `disconnector` field to match the `connector` one. Those fields are `NIL` by default.

* When `NIL`, the old behavior should be preserved for backwards compatibility - there's no attempt at calling the disconnector.
* When defined, the function will be called after any DB operation is performed to ensure no dangling connections.

This closes the issues I found with Caveman 2: fukamachi/caveman#99, fukamachi/caveman#98

As a side note, an even better change might be to allow the user of Lack to pass an already open connection for session data handling, so that the code here doesn't open or close anything - the connection just stays alive. Would that be desirable as an option?