### PR TITLE
Now request object has slot uri-scheme, accessible as request-uri-scheme

### DIFF
--- a/src/request.lisp
+++ b/src/request.lisp
@@ -19,6 +19,7 @@
            :request-server-port
            :request-server-protocol
            :request-uri
+           :request-uri-scheme
            :request-remote-addr
            :request-remote-port
            :request-query-string
@@ -44,6 +45,7 @@
   server-port
   server-protocol
   uri
+  uri-scheme
   remote-addr
   remote-port
   query-string
@@ -63,11 +65,14 @@
 
 (defun make-request (env)
   (let ((req (apply #'%make-request :env env :allow-other-keys t env)))
-    (with-slots (method uri) req
+    (with-slots (method uri uri-scheme) req
       (unless method
         (setf method (getf env :request-method)))
       (unless uri
-        (setf uri (getf env :request-uri))))
+        (setf uri (getf env :request-uri)))
+      (unless uri-scheme
+        ;; for some reason, it is called url-scheme in the environment plist :(
+        (setf uri-scheme (getf env :url-scheme))))
 
     ;; Cookies
     (unless (request-cookies req)


### PR DESCRIPTION
This change was made to make possible to write a function which will rebuild an original URI, used for a request.

Also lack.test:generate-env function was modified to work with fully qualified URIs. When you pass it something like https://example.com/foo/bar, it will set host and port of environment to example.com and 433.

This is useful for mocking requests, pretending that request was made to some particular host.