### PR TITLE
Responce could also be a pathname

### DIFF
--- a/src/response.lisp
+++ b/src/response.lisp
@@ -31,7 +31,8 @@
     (list* status headers
            (cond
              ((and no-body (not body)) nil)
-             ((consp body) (list body))
+             ((or (consp body) (pathnamep body))
+              (list body))
              (t (list (list body)))))))
 
 (defun finalize-cookies (res)


### PR DESCRIPTION
When 

``` cl
(setf (ningle:route *web* "/")
      (lambda (params)
	(declare (ignore params))
	  (merge-pathnames "index.html" *root*))))
```
the responce ends up as `(200 () (#p"pathname"))` When it should have been 
`(200 () #p"pathname")`
