### PR TITLE
Set a default content type.

### DIFF
--- a/src/request.lisp
+++ b/src/request.lisp
@@ -73,7 +73,9 @@
         (setf uri (getf env :request-uri)))
       (unless uri-scheme
         ;; for some reason, it is called url-scheme in the environment plist :(
-        (setf uri-scheme (getf env :url-scheme))))
+        (setf uri-scheme (getf env :url-scheme)))
+      (unless content-type
+        (setf content-type "application/octet-stream")))
 
     ;; Cookies
     (unless (request-cookies req)

--- a/src/request.lisp
+++ b/src/request.lisp
@@ -66,7 +66,7 @@
 
 (defun make-request (env)
   (let ((req (apply #'%make-request :env env :allow-other-keys t env)))
-    (with-slots (method uri uri-scheme) req
+    (with-slots (method uri uri-scheme content-type) req
       (unless method
         (setf method (getf env :request-method)))
       (unless uri


### PR DESCRIPTION
Otherwise a bad request is returned on post requests without a body.