### PR TITLE
fix accesslog's default formatter

### DIFF
--- a/src/middleware/accesslog.lisp
+++ b/src/middleware/accesslog.lisp
@@ -39,5 +39,5 @@
           (getf env :server-protocol)
           (car res)
           (content-length res)
-          (getf env :http-referer)
-          (getf env :http-user-agent)))
+          (gethash "referer" (getf env :headers))
+          (gethash "user-agent" (getf env :headers))))


### PR DESCRIPTION
The default formatter of accesslog middleware always outputs dashes for both `referer` and `user-agent` headers. Looks like the properties middleware tries to get this data from are not part of environment, and should be taken from `headers` property instead.

Please, feel free to close it in case you don't like it. :smile: 

