### PR TITLE
Fix browsers rejecting unsecure not-samesite cookies

### DIFF
--- a/src/middleware/session/state/cookie.lisp
+++ b/src/middleware/session/state/cookie.lisp
@@ -25,7 +25,7 @@
   (secure nil :type boolean)
   (httponly nil :type boolean)
   (cookie-key "lack.session" :type string)
-  (samesite :none :type keyword))
+  (samesite :lax :type keyword))
 
 (defmethod extract-sid ((state cookie-state) env)
   (let ((req (make-request env)))

--- a/src/response.lisp
+++ b/src/response.lisp
@@ -47,6 +47,9 @@
 
   (destructuring-bind (&key domain path expires secure httponly samesite &allow-other-keys)
       value
+    (unless (or (member samesite (list :lax :strict))
+                secure)
+      (warn "Samesite=None cookies require Secure"))
     (with-output-to-string (s)
       (format s "~A=~A"
               (quri:url-encode (string key))


### PR DESCRIPTION
There were two options to fix this. Either add `Secure` or remove `samesite=None`. I think it makes no sense to send our session-id to other sites so I used the latter.

Not sure if the warning is needed but it may go unnoticed in the browser.