### PR TITLE
Now memory session store will hold lock

### DIFF
--- a/lack-middleware-session.asd
+++ b/lack-middleware-session.asd
@@ -10,6 +10,7 @@
   :depends-on (:lack-request
                :lack-response
                :lack-util
+               :bordeaux-threads
                :cl-ppcre)
   :components ((:module "src/middleware"
                 :components


### PR DESCRIPTION
Without lock hash can be corrupted :(

This pull fixes issue  https://github.com/fukamachi/lack/issues/57