### PR TITLE
Replace ironclad dependency with cl-isaac

### DIFF
--- a/lack-util.asd
+++ b/lack-util.asd
@@ -7,7 +7,7 @@
   :version "0.1"
   :author "Eitaro Fukamachi"
   :license "LLGPL"
-  :depends-on (:ironclad)
+  :depends-on (:cl-isaac)
   :components ((:file "src/util"))
   :in-order-to ((test-op (test-op t-lack-util))))
 

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -86,6 +86,6 @@
 
 (defun generate-random-id ()
   "Generates a random token."
-  (format nil "~64,'0x" (#+:X86-64 isaac:rand-bits-64
-                         #-:X86-64 isaac:rand-bits
-                         *isaac-ctx* 512)))
+  (format nil "~(~40,'0x~)" (#+:X86-64 isaac:rand-bits-64
+                             #-:X86-64 isaac:rand-bits
+                             *isaac-ctx* 160)))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -87,5 +87,5 @@
 (defun generate-random-id ()
   "Generates a random token."
   (format nil "~64,'0x" (#+:X86-64 isaac:rand-bits-64
-                         #-:X86-64 isaac:rand-bits-32
+                         #-:X86-64 isaac:rand-bits
                          *isaac-ctx* 512)))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -1,9 +1,6 @@
 (in-package :cl-user)
 (defpackage lack.util
   (:use :cl)
-  (:import-from :ironclad
-                :byte-array-to-hex-string
-                :random-data)
   (:export :find-package-or-load
            :find-middleware
            :funcall-with-cb
@@ -81,7 +78,14 @@
           ((vector (unsigned-byte 8))
            (length body))))))
 
+;; cl-isaac supports ISAAC-64 solely for implementations with x86-64
+;; capabilities. Use whichever-best supported capability
+(defparameter *isaac-ctx*
+  (isaac:init-self-seed :count 5
+                        :is64 #+:X86-64 t #-:X86-64 nil))
+
 (defun generate-random-id ()
   "Generates a random token."
-  (ironclad:byte-array-to-hex-string
-    (ironclad:random-data 20)))
+  (format nil "~64,'0x" (#+:X86-64 isaac:rand-bits-64
+                         #-:X86-64 isaac:rand-bits-32
+                         *isaac-ctx* 512)))


### PR DESCRIPTION
Ironclad is a meaty dependency. This system takes the longest time on my
computer to compile my web application, and I've read comments online
that it adds ~19MB RAM usage in a lisp image.

This change switches ironclad with the single-purpose library `sha1` to
minimize lack's footprint, and the library `cl-isaac` for a
cryptographic PRNG for random session generation.
