### PR TITLE
accept header media type struct in lack.request object

### DIFF
--- a/lack-request.asd
+++ b/lack-request.asd
@@ -11,7 +11,10 @@
                :http-body
                :circular-streams
                :cl-ppcre)
-  :components ((:file "src/request"))
+  :components ((:module "src"
+                :components
+                ((:file "request" :depends-on ("media-type"))
+                 (:file "media-type"))))
   :in-order-to ((test-op (test-op t-lack-request))))
 
 (register-system-packages "lack-request" '(:lack.request))

--- a/src/media-type.lisp
+++ b/src/media-type.lisp
@@ -1,0 +1,41 @@
+(in-package :cl-user)
+(defpackage lack.media-type
+  (:use :cl)
+  (:import-from :quri
+                :url-decode-params)
+  (:import-from :cl-ppcre
+                :split)
+  (:export :media-type
+           :make-media-type
+           :media-type-main-type
+           :media-type-sub-type
+           :media-type-params
+           :match-media-type))
+
+(in-package :lack.media-type)
+
+(defstruct (media-type (:constructor %make-media-type))
+  main-type
+  sub-type
+  params)
+
+(defun make-media-type (media-type-string)
+  (let* ((media-type-pair (ppcre:split "\\s*[;]\\s*" media-type-string))
+         (media-type (ppcre:split "\\s*[/]\\s*" (first media-type-pair)))
+         (params (if (second media-type-pair)
+                     (quri:url-decode-params (second media-type-pair))
+                     nil)))
+    (%make-media-type :main-type (first media-type)
+                      :sub-type (second media-type)
+                      :params params)))
+
+(defun match-media-type (request-media-type other-media-type)
+  (with-slots ((request-main-type main-type) (request-sub-type sub-type)) request-media-type
+    (with-slots ((other-main-type main-type) (other-sub-type sub-type)) other-media-type
+      (cond ((and (string= request-main-type "*")
+                  (string= request-sub-type "*"))
+             t)
+            ((and (string= request-main-type other-main-type)
+                  (member request-sub-type (list "*" other-sub-type) :test #'string=))
+             t)
+            (t nil)))))

--- a/t-lack-request.asd
+++ b/t-lack-request.asd
@@ -14,7 +14,8 @@
                :flexi-streams
                :alexandria)
   :components
-  ((:test-file "t/request"))
+  ((:test-file "t/request")
+   (:test-file "t/media-type"))
 
   :defsystem-depends-on (:prove-asdf)
   :perform (test-op :after (op c)

--- a/t/media-type.lisp
+++ b/t/media-type.lisp
@@ -1,0 +1,41 @@
+(in-package #:cl-user)
+(defpackage #:t.lack.media-type
+  (:use #:cl
+        #:prove
+        #:lack.media-type))
+(in-package #:t.lack.media-type)
+
+(plan nil)
+
+(defparameter *media-type* (make-media-type "application/json;q=0.8"))
+
+(is (media-type-main-type *media-type*)
+    "application")
+
+(is (media-type-sub-type *media-type*)
+    "json")
+
+(is (media-type-params *media-type*)
+    '(("q" . "0.8")))
+
+(is (match-media-type (make-media-type "*/*;q=0.8")
+                      (make-media-type "text/html"))
+    t)
+
+(is (match-media-type (make-media-type "application/*")
+                      (make-media-type "application/json"))
+    t)
+
+(is (match-media-type (make-media-type "application/*")
+                      (make-media-type "text/html"))
+    nil)
+
+(is (match-media-type (make-media-type "application/json")
+                      (make-media-type "application/json"))
+    t)
+
+(is (match-media-type (make-media-type "application/json")
+                      (make-media-type "application/xml"))
+    nil)
+
+(finalize)

--- a/t/request.lisp
+++ b/t/request.lisp
@@ -25,6 +25,7 @@
                   :headers ,(alexandria:alist-hash-table
                              '(("referer" . "http://github.com/fukamachi/clack")
                                ("user-agent" . "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; en-US)")
+                               ("accept" . "text/html")
                                ("cookie" . "hoge=1;fuga=semi;colon"))
                              :test 'equal))))
 
@@ -48,6 +49,12 @@
 (is (request-cookies *request*)
     '(("hoge" . "1") ("fuga" . "semi") ("colon"))
     "request-cookies")
+
+(is (request-accepts-p *request* "text/html")
+    t)
+
+(is (request-accepts-p *request* "application/json")
+    nil)
 
 #+thread-support
 (subtest-app "make-request"


### PR DESCRIPTION
Added support for media type structs and parse accept header with them. Added a method to match media type string against the request object.