### PR TITLE
Update on the session middleware and its use of a lock

### DIFF
--- a/src/middleware/session/store.lisp
+++ b/src/middleware/session/store.lisp
@@ -10,6 +10,11 @@
 
 (defstruct store)
 
-(defgeneric fetch-session (store sid))
-(defgeneric store-session (store sid session))
-(defgeneric remove-session (store sid))
+(defgeneric fetch-session (store sid)
+  (:documentation "Grab a session from STORE using SID."))
+
+(defgeneric store-session (store sid session)
+  (:documentation "Store a SESSION in STORE using SID."))
+
+(defgeneric remove-session (store sid)
+  (:documentation "Remove a session from STORE using SID."))

--- a/src/middleware/session/store/memory.lisp
+++ b/src/middleware/session/store/memory.lisp
@@ -18,38 +18,22 @@ middleware
 ;;;for SBCL use the synchronized hash table rather than manually grabbing and releasing
 ;;;a lock on each call.
 
-#+sbcl
 (defstruct (memory-store (:include store))
-  (stash (make-hash-table :test 'equal :synchronized t)))
+  #+sbcl (stash (make-hash-table :test 'equal :synchronized t))
+  #-sbcl (stash (make-hash-table :test 'equal))
+  #-sbcl (lock (bt:make-lock "Lock for session store")))
 
-#-sbcl
-(defstruct (memory-store (:include store))
-  (stash (make-hash-table :test 'equal))
-  (lock (bordeaux-threads:make-lock "session store lock")))
-
-#+sbcl
 (defmethod fetch-session ((store memory-store) sid)
-  (gethash sid (memory-store-stash store)))
+  #+sbcl (gethash sid (memory-store-stash store))
+  #-sbcl (bt:with-lock-held ((memory-store-lock store))
+           (gethash sid (memory-store-stash store))))
 
-#-sbcl
-(defmethod fetch-session ((store memory-store) sid)
-  (bordeaux-threads:with-lock-held ((memory-store-lock store))
-    (gethash sid (memory-store-stash store))))
-
-#+sbcl
 (defmethod store-session ((store memory-store) sid session)
-  (setf (gethash sid (memory-store-stash store)) session))
+  #+sbcl (setf (gethash sid (memory-store-stash store)) session)
+  #-sbcl (bt:with-lock-held ((memory-store-lock store))
+           (setf (gethash sid (memory-store-stash store)) session)))
 
-#-sbcl 
-(defmethod store-session ((store memory-store) sid session)
-  (bordeaux-threads:with-lock-held ((memory-store-lock store))
-    (setf (gethash sid (memory-store-stash store)) session)))
-
-#+sbcl
 (defmethod remove-session ((store memory-store) sid)
-  (remhash sid (memory-store-stash store)))
-
-#-sbcl
-(defmethod remove-session ((store memory-store) sid)
-  (bordeaux-threads:with-lock-held ((memory-store-lock store))
-    (remhash sid (memory-store-stash store))))
+  #+sbcl (remhash sid (memory-store-stash store))
+  #-sbcl (bt:with-lock-held ((memory-store-lock store))
+           (remhash sid (memory-store-stash store))))

--- a/src/middleware/session/store/memory.lisp
+++ b/src/middleware/session/store/memory.lisp
@@ -7,11 +7,11 @@ middleware
 (defpackage lack.middleware.session.store.memory
   (:nicknames :lack.session.store.memory)
   (:use :cl
-   :lack.middleware.session.store)
+        :lack.middleware.session.store)
   (:export :memory-store
-   :make-memory-store
+           :make-memory-store
            :fetch-session
-   :store-session
+           :store-session
            :remove-session))
 (in-package :lack.middleware.session.store.memory)
 

--- a/src/middleware/session/store/memory.lisp
+++ b/src/middleware/session/store/memory.lisp
@@ -1,28 +1,55 @@
+#||
+Implement the protocol for storing, fetching, and removing a session from Clacks session 
+middleware
+||#
+
 (in-package :cl-user)
 (defpackage lack.middleware.session.store.memory
   (:nicknames :lack.session.store.memory)
   (:use :cl
-        :lack.middleware.session.store)
+   :lack.middleware.session.store)
   (:export :memory-store
-           :make-memory-store
+   :make-memory-store
            :fetch-session
-           :store-session
+   :store-session
            :remove-session))
 (in-package :lack.middleware.session.store.memory)
 
+;;;for SBCL use the synchronized hash table rather than manually grabbing and releasing
+;;;a lock on each call.
+
+#+sbcl
+(defstruct (memory-store (:include store))
+  (stash (make-hash-table :test 'equal :synchronized t)))
+
+#-sbcl
 (defstruct (memory-store (:include store))
   (stash (make-hash-table :test 'equal))
   (lock (bordeaux-threads:make-lock "session store lock")))
 
+#+sbcl
+(defmethod fetch-session ((store memory-store) sid)
+  (gethash sid (memory-store-stash store)))
+
+#-sbcl
 (defmethod fetch-session ((store memory-store) sid)
   (bordeaux-threads:with-lock-held ((memory-store-lock store))
-      (gethash sid (memory-store-stash store))))
+    (gethash sid (memory-store-stash store))))
 
+#+sbcl
+(defmethod store-session ((store memory-store) sid session)
+  (setf (gethash sid (memory-store-stash store)) session))
+
+#-sbcl 
 (defmethod store-session ((store memory-store) sid session)
   (bordeaux-threads:with-lock-held ((memory-store-lock store))
-    (setf (gethash sid (memory-store-stash store))
-          session)))
+    (setf (gethash sid (memory-store-stash store)) session)))
 
+#+sbcl
+(defmethod remove-session ((store memory-store) sid)
+  (remhash sid (memory-store-stash store)))
+
+#-sbcl
 (defmethod remove-session ((store memory-store) sid)
   (bordeaux-threads:with-lock-held ((memory-store-lock store))
     (remhash sid (memory-store-stash store))))


### PR DESCRIPTION
This is just a simple update on: https://github.com/fukamachi/lack/pull/58
Now uses :synchronized on SBCL and a lock on everything else. I have also added some doc strings. 
Thanks.