### PR TITLE
Fixing cl-isaac related bugs

### DIFF
--- a/lack-util.asd
+++ b/lack-util.asd
@@ -3,7 +3,8 @@
   :author "Eitaro Fukamachi"
   :license "MIT"
   :depends-on ((:feature (:or :windows :mswindows :win32 :cormanlisp) "ironclad")
-               (:feature (:not (:or :windows :mswindows :win32 :cormanlisp)) "cl-isaac"))
+               (:feature (:not (:or :windows :mswindows :win32 :cormanlisp)) "cl-isaac")
+	       "bordeaux-threads")
   :components ((:file "src/util"))
   :in-order-to ((test-op (test-op "t-lack-util"))))
 

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -5,6 +5,9 @@
   (:import-from :ironclad
                 :byte-array-to-hex-string
                 :random-data)
+  (:import-from :bordeaux-threads
+		:make-lock
+		:with-lock-held)
   (:export :find-package-or-load
            :find-middleware
            :funcall-with-cb
@@ -89,6 +92,33 @@
           ((vector (unsigned-byte 8))
            (length body))))))
 
+;; Patch to fix bug in cl-isaac.
+;; When PR is accepted in cl-isaac, the code below can be removed
+
+(defun cl-isaac:rand32 (ctx)
+  ;;(declare (optimize (speed 3) (safety 0)))
+  (cond
+    ((zerop (cl-isaac::isaac-ctx-randcnt ctx))
+     (cl-isaac::generate-next-isaac-block ctx)
+     (setf (cl-isaac::isaac-ctx-randcnt ctx) 255)
+     (aref (cl-isaac::isaac-ctx-randrsl ctx) 255))
+    (t
+     (aref (cl-isaac::isaac-ctx-randrsl ctx)
+           (decf (cl-isaac::isaac-ctx-randcnt ctx))))))
+
+(defun cl-isaac:rand64 (ctx)
+  ;;(declare (optimize (speed 3) (safety 0)))
+  (cond
+    ((zerop (cl-isaac::isaac64-ctx-randcnt ctx))
+     (cl-isaac::generate-next-isaac64-block ctx)
+     (setf (cl-isaac::isaac64-ctx-randcnt ctx) 255)
+     (aref (cl-isaac::isaac64-ctx-randrsl ctx) 255))
+    (t
+     (aref (cl-isaac::isaac64-ctx-randrsl ctx)
+           (decf (cl-isaac::isaac64-ctx-randcnt ctx))))))
+
+;; End of cl-isaac patch
+
 ;; cl-isaac supports ISAAC-64 solely for implementations with x86-64
 ;; capabilities. Use whichever-best supported capability
 #-(or windows mswindows win32 cormanlisp)
@@ -96,12 +126,19 @@
   (isaac:init-self-seed :count 5
                         :is64 #+:X86-64 t #-:X86-64 nil))
 
+(defvar *isaac-ctx-lock* (bordeaux-threads:make-lock))
+
 (defun generate-random-id ()
   "Generates a random token."
   #+(or windows mswindows win32 cormanlisp)
   (ironclad:byte-array-to-hex-string
     (ironclad:random-data 20))
   #-(or windows mswindows win32 cormanlisp)
-  (format nil "~(~40,'0x~)" (#+:X86-64 isaac:rand-bits-64
-                             #-:X86-64 isaac:rand-bits
-                             *isaac-ctx* 160)))
+  (format nil "~(~40,'0x~)"
+	  (let ((output-string NIL))
+	    (bordeaux-threads:with-lock-held (*isaac-ctx-lock*)
+	      (setf output-string
+		    (#+:X86-64 isaac:rand-bits-64
+		     #-:X86-64 isaac:rand-bits
+		     *isaac-ctx* 160)))
+	    output-string)))


### PR DESCRIPTION
Adding cl-isaac patch and adding threads lock for seed for random number generation, added dependency on bordeaux threads.

This fixes the problems mentioned in [Issue 81](https://github.com/fukamachi/lack/issues/81) which are two:
- Thread safety problem: The seed has to be used with a lock for thread safety
- The code of number generation in cl-isaac has a bug, [see this issue](https://github.com/thephoeron/cl-isaac/issues/12) for details. A [PR](https://github.com/thephoeron/cl-isaac/pull/13/files) was added by @svetlyak40wt , however the maintainer for the repo is unresponsive. I added the changes from the PR as a patch here.

Once the cl-isaac repo accepts the PR we can delete the patch code from here. The threads code however, we need to keep.