### PR TITLE
Feat: media-type, request, response slot types

### DIFF
--- a/src/media-type.lisp
+++ b/src/media-type.lisp
@@ -14,9 +14,9 @@
 (in-package :lack/media-type)
 
 (defstruct (media-type (:constructor %make-media-type))
-  main-type
-  sub-type
-  params)
+  (main-type nil :type (or null string))
+  (sub-type nil :type (or null string))
+  (params nil :type list))
 
 (defun make-media-type (media-type-string)
   (let* ((media-type-pair (ppcre:split "\\s*[;]\\s*" media-type-string))

--- a/src/request.lisp
+++ b/src/request.lisp
@@ -43,28 +43,28 @@
 (in-package :lack/request)
 
 (defstruct (request (:constructor %make-request))
-  env
+  (env nil :type list)
 
-  method
-  script-name
-  path-info
-  server-name
-  server-port
-  server-protocol
-  uri
-  uri-scheme
-  remote-addr
-  remote-port
-  query-string
-  raw-body
-  content-length
-  content-type
-  headers
+  (method nil :type (or null keyword))
+  (script-name nil :type (or null string))
+  (path-info nil :type (or null string))
+  (server-name nil :type (or null string))
+  (server-port nil :type (or null integer))
+  (server-protocol nil :type (or null keyword))
+  (uri nil :type (or null string))
+  (uri-scheme nil :type (or null string keyword))
+  (remote-addr nil :type (or null string))
+  (remote-port nil :type (or null keyword integer))
+  (query-string nil :type (or null string))
+  (raw-body nil :type (or null stream))
+  (content-length nil :type (or null integer))
+  (content-type nil :type (or null string))
+  (headers nil :type (or null hash-table))
 
-  cookies
-  body-parameters
-  query-parameters
-  accept)
+  (cookies nil :type list)
+  (body-parameters nil :type list)
+  (query-parameters nil :type list)
+  (accept nil :type list))
 
 (declaim (inline request-has-body-p))
 (defun request-has-body-p (req)

--- a/src/response.lisp
+++ b/src/response.lisp
@@ -19,11 +19,11 @@
 (defstruct (response
             (:constructor make-response (&optional status headers (body nil has-body)
                                          &aux (no-body (not has-body)))))
-  status
-  headers
-  body
-  no-body
-  set-cookies)
+  (status nil :type (integer 100 599))
+  (headers nil :type list)
+  (body nil :type (or vector pathname list))
+  (no-body nil :type boolean)
+  (set-cookies nil :type list))
 
 (defun finalize-response (res)
   (finalize-cookies res)


### PR DESCRIPTION
Add types to the structs `media-type`, `request`, `response`.

Tests are succeeding so far, but maybe more tests should be performed.

Also I was not sure whether the default value for some slots of type string should be `nil` or `""`.
This mainly applies for required slots of `request`: e.g. `script-name`, `path-info`, `request-uri`, `remote-addr`.