### PR TITLE
Fix register-system-packages typo in lack-util-writer-stream.asd

### DIFF
--- a/lack-util-writer-stream.asd
+++ b/lack-util-writer-stream.asd
@@ -6,4 +6,4 @@
                "babel")
   :components ((:file "src/util/writer-stream")))
 
-(register-system-packages "lack-util-write-stream" '(:lack.util.writer-stream))
+(register-system-packages "lack-util-writer-stream" '(:lack.util.writer-stream))


### PR DESCRIPTION
The register-system-packages command was missing a letter, causing an error on load.