### PR TITLE
update SCRIPT_NAME in environment when mounting sub-apps

### DIFF
--- a/src/middleware/mount.lisp
+++ b/src/middleware/mount.lisp
@@ -14,13 +14,18 @@
           (cond
             ((string= path-info path)
              (setf (getf env :path-info) "/")
+             (setf (getf env :script-name)
+                   (format nil "~A~A" (or (getf env :script-name) "") path))
              (funcall (to-app mount-app) env))
             ((and (< len (length path-info))
                   (string= path-info path :end1 len)
                   (char= (aref path-info len) #\/))
              (setf (getf env :path-info)
                    (subseq path-info (length path)))
+             (setf (getf env :script-name)
+                   (format nil "~A~A" (or (getf env :script-name) "") path))
              (funcall (to-app mount-app) env))
             (t
              (funcall app env)))))))
   "Middleware for attaching another Lack application on a specific URL")
+

--- a/tests/middleware/mount.lisp
+++ b/tests/middleware/mount.lisp
@@ -64,3 +64,32 @@
              response))))
     (dolist (path (list "/mount1" "/mount2/test" "/test"))
       (funcall app (generate-env path))))))
+
+(deftest script-name
+  (macrolet ((is-script-name (env expected &optional comment)
+               `(ok (equal (getf ,env :script-name)
+                           ,expected)
+                    ,@(when comment (list comment)))))
+    (let* ((response '(200 () ("ok")))
+           (app
+             (builder
+              (:mount "/mount1"
+                      (lambda (env)
+                        (is-script-name env "/mount1" "exact match.")
+                        response))
+              (:mount "/mount2"
+                      (builder
+                       (:mount "/sub"
+                               (lambda (env)
+                                 (is-script-name env "/mount2/sub" "nested mount.")
+                                 response))
+                       (lambda (env)
+                         (is-script-name env "/mount2" "subseq match.")
+                         response)))
+              (lambda (env)
+                (is-script-name env "" "root app (not mounted).")
+                response))))
+      (dolist (path (list "/mount1" "/mount2/test" "/mount2/sub/deep" "/test"))
+        (funcall app (generate-env path))))))
+
+


### PR DESCRIPTION
`lack-middleware-mount` stripped the mount prefix from `:path-info` but
    omitted updating `:script-name`, leaving it as an empty string (`""`)
    inside mounted sub-applications.

    According to the Clack/WSGI/Rack specifications, `SCRIPT_NAME` represents
    the application's mount point and `PATH_INFO` represents the path within
    the application (`REQUEST_URI = SCRIPT_NAME + PATH_INFO`). Leaving
    `SCRIPT_NAME` empty prevents mounted sub-applications (like Ningle, Caveman,
    or custom Clack apps) from discovering their mount path to construct reverse
    routes, form actions, and redirects.

    This change:
    - Appends the mount prefix to `:script-name` on exact and sub-path matches
    - Supports multi-level / nested mounts
    - Preserves unmounted root app `:script-name` behavior
    - Adds unit test coverage for `:script-name` in `tests/middleware/mount.lisp`