### PR TITLE
Fix/session cookie expiration

### DIFF
--- a/src/middleware/session/state/cookie.lisp
+++ b/src/middleware/session/state/cookie.lisp
@@ -22,7 +22,7 @@
 (defstruct (cookie-state (:include state))
   (path "/" :type string)
   (domain nil :type (or string null))
-  (expires (get-universal-time) :type integer)
+  (expires nil :type (or integer null))
   (secure nil :type boolean)
   (httponly nil :type boolean)
   (cookie-key "lack.session" :type string)
@@ -52,13 +52,14 @@
 
   (let ((res (apply #'make-response res))
         (options (with-slots (path domain expires secure httponly samesite) state
-                   (list :path path
-                         :domain domain
-                         :secure secure
-                         :httponly httponly
-                         :samesite samesite
-                         :expires (+ (get-universal-time)
-                                     (getf options :expires expires))))))
+                   (let ((expire-delta (getf options :expires expires)))
+                     (list :path path
+                           :domain domain
+                           :secure secure
+                           :httponly httponly
+                           :samesite samesite
+                           :expires (when expire-delta
+                                      (+ (get-universal-time) expire-delta)))))))
     (setf (getf (response-set-cookies res) (cookie-state-cookie-key state))
           `(:value ,sid ,@options))
     (finalize-response res)))

--- a/tests/middleware/session.lisp
+++ b/tests/middleware/session.lisp
@@ -189,4 +189,40 @@
       (destructuring-bind (status headers body)
           (funcall app (generate-env "/"))
         (declare (ignore status body))
-        (ok (ppcre:scan "^_myapp_cookie=" (getf headers :set-cookie)))))))
+        (ok (ppcre:scan "^_myapp_cookie=" (getf headers :set-cookie))))))
+
+  (testing "session cookie with :expires nil (browser session cookie)"
+    (let ((app (builder
+                (:session :state (lack.session.state.cookie:make-cookie-state
+                                  :expires nil))
+                (lambda (env)
+                  (declare (ignore env))
+                  '(200 () ("hi"))))))
+      (destructuring-bind (status headers body)
+          (funcall app (generate-env "/"))
+        (declare (ignore status body))
+        (let ((set-cookie (getf headers :set-cookie)))
+          (ok set-cookie "Set-Cookie header exists")
+          (ng (ppcre:scan "(?i)expires=" set-cookie)
+              "session cookie with :expires nil should omit expires attribute")
+          (let ((cookie (cookie:parse-set-cookie-header set-cookie "" "")))
+            (ok (null (cookie:cookie-expires cookie))
+                "parsed cookie should have no expires attribute"))))))
+
+  (testing "default session cookie should not expire in the distant future"
+    (let ((app (builder
+                :session
+                (lambda (env)
+                  (declare (ignore env))
+                  '(200 () ("hi"))))))
+      (destructuring-bind (status headers body)
+          (funcall app (generate-env "/"))
+        (declare (ignore status body))
+        (let* ((set-cookie (getf headers :set-cookie))
+               (cookie (cookie:parse-set-cookie-header set-cookie "" "")))
+          (ok set-cookie "Set-Cookie header exists")
+          (if (cookie:cookie-expires cookie)
+              (ok (< (- (cookie:cookie-expires cookie) (get-universal-time))
+                     (* 60 60 24 365))
+                  "cookie expiration must not be more than 1 year in the future")
+              (pass "default session cookie has no expires attribute")))))))

--- a/tests/middleware/session.lisp
+++ b/tests/middleware/session.lisp
@@ -128,8 +128,9 @@
       (ok (getf headers :set-cookie)
           "Set-Cookie header exists")
       (let ((cookie (cookie:parse-set-cookie-header (getf headers :set-cookie) "" "")))
-        (ok (> (cookie:cookie-expires cookie)
-               (get-universal-time))
+        (ok (or (null (cookie:cookie-expires cookie))
+                (> (cookie:cookie-expires cookie)
+                   (get-universal-time)))
             "new session is not expired"))
       (ok (equalp body '("hi")) "body")))
 
@@ -225,4 +226,24 @@
               (ok (< (- (cookie:cookie-expires cookie) (get-universal-time))
                      (* 60 60 24 365))
                   "cookie expiration must not be more than 1 year in the future")
-              (pass "default session cookie has no expires attribute")))))))
+              (pass "default session cookie has no expires attribute"))))))
+
+  (testing "session cookie with explicit integer :expires"
+    (let ((app (builder
+                (:session :state (lack.session.state.cookie:make-cookie-state
+                                  :expires 86400))
+                (lambda (env)
+                  (declare (ignore env))
+                  '(200 () ("hi"))))))
+      (destructuring-bind (status headers body)
+          (funcall app (generate-env "/"))
+        (declare (ignore status body))
+        (let* ((set-cookie (getf headers :set-cookie))
+               (cookie (cookie:parse-set-cookie-header set-cookie "" "")))
+          (ok set-cookie "Set-Cookie header exists")
+          (ok (cookie:cookie-expires cookie)
+              "cookie with explicit :expires has an expires attribute")
+          (ok (> (cookie:cookie-expires cookie) (get-universal-time))
+              "cookie expires in the future")
+          (ok (<= (- (cookie:cookie-expires cookie) (get-universal-time)) 86400)
+              "cookie expires within 86400 seconds"))))))


### PR DESCRIPTION
* Set cookie to potentially be nil to allow for compliance with [RFC 6265 Section 4.1.2.2](https://www.rfc-editor.org/info/rfc6265/#section-4.1.2.2)
* Added a expires delta so that current universal time isn't added to current universal time (creating an expires date ~127 years in the future)
* Added test cases for the above